### PR TITLE
Support GNU-style long filenames

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -53,10 +53,6 @@ jobs:
       - name: "Download 7za"
         run: dart run tool/download_7za.dart
         if: runner.os == 'Windows'
-
-      - name: Install truncate (macOS)
-        run: brew install truncate
-        if: runner.os == 'macOS'
       
       - name: "Run tests"
         run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -46,9 +46,13 @@ jobs:
         with:
           path: .dart_tool
           key: dart-tool-${{ hashFiles('pubspec.yaml') }}
-      
+            
       - name: "Get dependencies"
         run: dart pub get
+
+      - name: "Download 7za"
+        run: dart run tool/download_7za.dart
+        if: runner.os == 'Windows'
       
       - name: "Run tests"
-        run: dart test    
+        run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -53,6 +53,10 @@ jobs:
       - name: "Download 7za"
         run: dart run tool/download_7za.dart
         if: runner.os == 'Windows'
+
+      - name: Install truncate (macOS)
+        run: brew install truncate
+        if: runner.os == 'macOS'
       
       - name: "Run tests"
         run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,39 +6,49 @@ on:
   pull_request:
     branches: [ main ]
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
+env:
+  PUB_ENVIRONMENT: bot.github
+  PUB_CACHE: ".dart_tool/pub_cache"
 
-    container:
-      image:  google/dart:beta
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - uses: actions/cache@v2
+        with:
+          path: .dart_tool
+          key: dart-tool-${{ hashFiles('pubspec.yaml') }}
+
+      - name: "Install dependencies"
+        run: dart pub upgrade
+      
+      - name: "Ensure formatted"
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: "Analyze project"
+        run: dart analyze --fatal-infos
+  
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    # analyze creates the cache, avoid downloading dependencies again here
+    needs: analyze
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Print Dart SDK version
-        run: dart --version
-
-      - name: Cache pub dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: tar-cache-deps
+      - uses: dart-lang/setup-dart@v1
+      - uses: actions/cache@v2
         with:
           path: .dart_tool
-          key: ${{ env.cache-name }}
-
-      - name: Install dependencies
-        env: 
-          PUB_CACHE: ".dart_tool/pub_cache"
+          key: dart-tool-${{ hashFiles('pubspec.yaml') }}
+      
+      - name: "Get dependencies"
         run: dart pub get
-
-      - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
-
-      - name: Analyze project source
-        run: dart analyze --fatal-infos
-
-      - name: Run tests
-        env:
-          PUB_CACHE: ".dart_tool/pub_cache"
-        run: dart test
+      
+      - name: "Run tests"
+        run: dart test    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Support generating tar files with GNU-style long link names
+ - Add `format` parameter to `tarWritingSink` and `tarTransformerWith`
+
 ## 0.3.3
 
 - Drop `chunked_stream` dependency in favor of `package:async`.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,6 @@ Future<void> main() async {
 }
 ```
 
-Note that tar files are always written in the pax format defined by the POSIX.1-2001 specification
-(`--format=posix` in GNU tar).
-When all entries have file names shorter than 100 chars and a size smaller than 8 GB, this is
-equivalent to the `ustar` format. This library won't write PAX headers when there is no reason to do so.
-
 To write `.tar.gz` files, you can again transform the stream twice:
 
 ```dart
@@ -92,6 +87,25 @@ Future<void> write(Stream<TarEntry> entries) {
       .transform(tarWriter)
       .transform(gzip.encoder)
       .pipe(File('output.tar.gz').openWrite());
+}
+```
+
+Note that, by default, tar files are  written in the pax format defined by the
+POSIX.1-2001 specification (`--format=posix` in GNU tar).
+When all entries have file names shorter than 100 chars and a size smaller 
+than 8 GB, this is equivalent to the `ustar` format. This library won't write
+PAX headers when there is no reason to do so.
+If you prefer writing GNU-style long filenames instead, you can use the
+`format` option:
+
+```dart
+Future<void> write(Stream<TarEntry> entries) {
+  return entries
+      .transform(tarWriterWith(format: OutputFormat.gnuLongName))
+      .pipe(tarWritingSink(
+        File('output.tar.gz').openWrite(),
+        format: OutputFormat.gnuLongName,
+      ));
 }
 ```
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:extra_pedantic/analysis_options.yaml
+include: package:extra_pedantic/analysis_options.1.3.0.yaml 
 
 analyzer:
   strong-mode:
@@ -15,3 +15,5 @@ linter:
     literal_only_boolean_expressions: false # Nothing wrong with a little while(true)
     parameter_assignments: false
     unnecessary_await_in_return: false
+    no_default_cases: false
+    prefer_asserts_with_message: false # We only use asserts for library-internal invariants

--- a/lib/src/reader.dart
+++ b/lib/src/reader.dart
@@ -803,8 +803,8 @@ class PaxHeaders extends UnmodifiableMapBase<String, String> {
       // If we're seeing weird PAX Version 0.0 sparse keys, expect alternating
       // GNU.sparse.offset and GNU.sparse.numbytes headers.
       if (key == paxGNUSparseNumBytes || key == paxGNUSparseOffset) {
-        if ((sparseMap.length % 2 == 0 && key != paxGNUSparseOffset) ||
-            (sparseMap.length % 2 == 1 && key != paxGNUSparseNumBytes) ||
+        if ((sparseMap.length.isEven && key != paxGNUSparseOffset) ||
+            (sparseMap.length.isOdd && key != paxGNUSparseNumBytes) ||
             value.contains(',')) {
           error();
         }

--- a/lib/src/writer.dart
+++ b/lib/src/writer.dart
@@ -212,7 +212,6 @@ class _WritingSink extends StreamSink<TarEntry> {
       if (format == OutputFormat.pax) {
         await _writePaxHeader(paxHeader);
       } else {
-        assert(format == OutputFormat.gnuLongName);
         await _writeGnuLongName(paxHeader);
       }
     }

--- a/lib/src/writer.dart
+++ b/lib/src/writer.dart
@@ -5,18 +5,22 @@ import 'dart:typed_data';
 import 'charcodes.dart';
 import 'constants.dart';
 import 'entry.dart';
+import 'exception.dart';
 import 'format.dart';
 import 'header.dart';
+import 'utils.dart';
 
 class _WritingTransformer extends StreamTransformerBase<TarEntry, List<int>> {
-  const _WritingTransformer();
+  final OutputFormat format;
+
+  const _WritingTransformer(this.format);
 
   @override
   Stream<List<int>> bind(Stream<TarEntry> stream) {
     // sync because the controller proxies another stream
     final controller = StreamController<List<int>>(sync: true);
     controller.onListen = () {
-      stream.pipe(tarWritingSink(controller));
+      stream.pipe(tarWritingSink(controller, format: format));
     };
 
     return controller.stream;
@@ -32,7 +36,29 @@ class _WritingTransformer extends StreamTransformerBase<TarEntry, List<int>> {
 ///
 /// When piping the resulting stream into a [StreamConsumer], consider using
 /// [tarWritingSink] directly.
-const StreamTransformer<TarEntry, List<int>> tarWriter = _WritingTransformer();
+const StreamTransformer<TarEntry, List<int>> tarWriter =
+    _WritingTransformer(OutputFormat.pax);
+
+/// Creates a stream transformer writing tar entries as byte streams, with
+/// custom encoding options.
+///
+/// The [format] [OutputFormat] can be used to select the way tar entries with
+/// long file or link names are written. By default, the writer will emit an
+/// extended PAX header for the file ([OutputFormat.pax]).
+/// Alternatively, [OutputFormat.gnuLongName] can be used to emit special tar
+/// entries with the [TypeFlag.gnuLongName] type.
+///
+/// Regardless of the input stream, the stream returned by this
+/// [StreamTransformer.bind] is a single-subscription stream.
+/// Apart from that, subscriptions, cancellations, pauses and resumes are
+/// propagated as one would expect from a [StreamTransformer].
+///
+/// When using the default options, prefer using the constant [tarWriter]
+/// instead.
+StreamTransformer<TarEntry, List<int>> tarWriterWith(
+    {OutputFormat format = OutputFormat.pax}) {
+  return _WritingTransformer(format);
+}
 
 /// Create a sink emitting encoded tar files to the [output] sink.
 ///
@@ -62,15 +88,39 @@ const StreamTransformer<TarEntry, List<int>> tarWriter = _WritingTransformer();
 /// Note that, if you don't set the [TarHeader.size], outgoing tar entries need
 /// to be buffered once, which decreases performance.
 ///
+/// The [format] argument can be used to control how long file names are written
+/// in the tar archive. For more details, see the options in [OutputFormat].
+///
 /// See also:
 ///  - [tarWriter], a stream transformer using this sink
 ///  - [StreamSink]
-StreamSink<TarEntry> tarWritingSink(StreamSink<List<int>> output) {
-  return _WritingSink(output);
+StreamSink<TarEntry> tarWritingSink(StreamSink<List<int>> output,
+    {OutputFormat format = OutputFormat.pax}) {
+  return _WritingSink(output, format);
+}
+
+/// This option controls how long file and link names should be written.
+///
+/// This option can be passed to writer in [tarWritingSink] or[tarWriterWith].
+enum OutputFormat {
+  /// Generates an extended PAX headers to encode files with a long name.
+  ///
+  /// This is the default option.
+  pax,
+
+  /// Generates [TypeFlag.gnuLongName] or [TypeFlag.gnuLongLink] entries when
+  /// encoding files with a long name.
+  ///
+  /// When this option is set, `package:tar` will not emit PAX headers which
+  /// may improve compatibility with other tar readers like 7zip. On the other
+  /// hand, some other options like huge files or long user names are not
+  /// supported with this option and might throw an exception.
+  gnuLongName,
 }
 
 class _WritingSink extends StreamSink<TarEntry> {
   final StreamSink<List<int>> _output;
+  final OutputFormat format;
 
   int _paxHeaderCount = 0;
   bool _closed = false;
@@ -79,7 +129,7 @@ class _WritingSink extends StreamSink<TarEntry> {
   int _pendingOperations = 0;
   Future<void> _ready = Future.value();
 
-  _WritingSink(this._output);
+  _WritingSink(this._output, this.format);
 
   @override
   Future<void> get done => _done.future;
@@ -127,6 +177,7 @@ class _WritingSink extends StreamSink<TarEntry> {
     // have to insert an entry just to store the names. Some tar implementations
     // expect them to be zero-terminated, so use 99 chars to be safe.
     final paxHeader = <String, List<int>>{};
+
     if (nameBytes.length > 99) {
       paxHeader[paxPath] = nameBytes;
       nameBytes = nameBytes.sublist(0, 99);
@@ -151,7 +202,12 @@ class _WritingSink extends StreamSink<TarEntry> {
     }
 
     if (paxHeader.isNotEmpty) {
-      await _writePaxHeader(paxHeader);
+      if (format == OutputFormat.pax) {
+        await _writePaxHeader(paxHeader);
+      } else {
+        assert(format == OutputFormat.gnuLongName);
+        await _writeGnuLongName(paxHeader);
+      }
     }
 
     final headerBlock = Uint8List(blockSize)
@@ -228,7 +284,7 @@ class _WritingSink extends StreamSink<TarEntry> {
     final file = TarEntry.data(
       HeaderImpl.internal(
         format: TarFormat.pax,
-        modified: DateTime.fromMillisecondsSinceEpoch(0),
+        modified: millisecondsSinceEpoch(0),
         name: 'PaxHeader/${_paxHeaderCount++}',
         mode: 0,
         size: paxData.length,
@@ -237,6 +293,41 @@ class _WritingSink extends StreamSink<TarEntry> {
       paxData,
     );
     return _safeAdd(file);
+  }
+
+  Future<void> _writeGnuLongName(Map<String, List<int>> values) async {
+    // Ensure that a file that can't be written in the GNU format is not written
+    const allowedKeys = {paxPath, paxLinkpath};
+    final invalidOptions = values.keys.toSet()..removeAll(allowedKeys);
+    if (invalidOptions.isNotEmpty) {
+      throw TarException('Invalid entry for OutputFormat.gnu. It uses long '
+          "fields that can't be represented: $invalidOptions. \n"
+          'Try using OutputFormat.pax instead.');
+    }
+
+    final name = values[paxPath];
+    final linkName = values[paxLinkpath];
+
+    Future<void> write(List<int> name, TypeFlag flag) {
+      return _safeAdd(
+        TarEntry.data(
+          HeaderImpl.internal(
+            name: '././@LongLink',
+            modified: millisecondsSinceEpoch(0),
+            format: TarFormat.gnu,
+            typeFlag: flag,
+          ),
+          name,
+        ),
+      );
+    }
+
+    if (name != null) {
+      await write(name, TypeFlag.gnuLongName);
+    }
+    if (linkName != null) {
+      await write(linkName, TypeFlag.gnuLongLink);
+    }
   }
 
   @override

--- a/lib/tar.dart
+++ b/lib/tar.dart
@@ -14,4 +14,4 @@ export 'src/exception.dart';
 export 'src/format.dart';
 export 'src/header.dart' show TarHeader;
 export 'src/reader.dart' show TarReader;
-export 'src/writer.dart' show tarWritingSink, tarWriter;
+export 'src/writer.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,4 +14,5 @@ dependencies:
 dev_dependencies:
   charcode: ^1.2.0
   extra_pedantic: ^1.2.0
+  path: ^1.8.0
   test: ^1.17.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
 
 dev_dependencies:
   charcode: ^1.2.0
-  extra_pedantic: ^1.2.0
+  extra_pedantic: ^1.4.0
   path: ^1.8.0
   test: ^1.17.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tar
 description: Memory-efficient, streaming implementation of the tar file format
-version: 0.3.3
+version: 0.4.0
 repository: https://github.com/simolus3/tar/
 
 environment:
@@ -14,4 +14,4 @@ dependencies:
 dev_dependencies:
   charcode: ^1.2.0
   extra_pedantic: ^1.2.0
-  test: ^1.16.0
+  test: ^1.17.4

--- a/test/reader_test.dart
+++ b/test/reader_test.dart
@@ -6,9 +6,8 @@ import 'dart:typed_data';
 import 'package:async/async.dart';
 import 'package:tar/src/reader.dart';
 import 'package:tar/src/utils.dart';
-import 'package:test/test.dart';
-
 import 'package:tar/tar.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('POSIX.1-2001', () {

--- a/test/sparse_test.dart
+++ b/test/sparse_test.dart
@@ -1,4 +1,4 @@
-@TestOn('!windows') // We currently use the tar executable to create test inputs
+@TestOn('linux') // We currently use gnu tar to create test inputs
 import 'dart:io';
 
 import 'dart:math';
@@ -137,11 +137,7 @@ void main() {
     return validate(tar, files);
   }
 
-  final allowedFormats = Platform.isLinux
-      ? {'gnu', 'v7', 'oldgnu', 'posix', 'ustar'}
-      : {'v7', 'posix', 'ustar'};
-
-  for (final format in allowedFormats) {
+  for (final format in ['gnu', 'v7', 'oldgnu', 'posix', 'ustar']) {
     group('reads large files in $format', () {
       test('single file', () {
         return testSubset(['reg_1'], format, null);
@@ -153,7 +149,7 @@ void main() {
     });
   }
 
-  for (final format in {'gnu', 'posix'}.intersection(allowedFormats)) {
+  for (final format in ['gnu', 'posix']) {
     for (final sparseVersion in ['0.0', '0.1', '1.0']) {
       group('sparse format $format, version $sparseVersion', () {
         test('reads a clean sparse file', () {

--- a/test/sparse_test.dart
+++ b/test/sparse_test.dart
@@ -137,7 +137,11 @@ void main() {
     return validate(tar, files);
   }
 
-  for (final format in ['gnu', 'v7', 'oldgnu', 'posix', 'ustar']) {
+  final allowedFormats = Platform.isLinux
+      ? {'gnu', 'v7', 'oldgnu', 'posix', 'ustar'}
+      : {'v7', 'posix', 'ustar'};
+
+  for (final format in allowedFormats) {
     group('reads large files in $format', () {
       test('single file', () {
         return testSubset(['reg_1'], format, null);
@@ -149,7 +153,7 @@ void main() {
     });
   }
 
-  for (final format in ['gnu', 'posix']) {
+  for (final format in {'gnu', 'posix'}.intersection(allowedFormats)) {
     for (final sparseVersion in ['0.0', '0.1', '1.0']) {
       group('sparse format $format, version $sparseVersion', () {
         test('reads a clean sparse file', () {

--- a/test/sparse_test.dart
+++ b/test/sparse_test.dart
@@ -1,3 +1,4 @@
+@TestOn('!windows') // We currently use the tar executable to create test inputs
 import 'dart:io';
 
 import 'dart:math';

--- a/test/system_tar.dart
+++ b/test/system_tar.dart
@@ -42,10 +42,10 @@ Stream<List<int>> createTarStream(Iterable<String> files,
   yield* tar.stdout;
 }
 
-Future<Process> writeToTar(
-    List<String> args, Stream<tar.TarEntry> entries) async {
+Future<Process> writeToTar(List<String> args, Stream<tar.TarEntry> entries,
+    {tar.OutputFormat format = tar.OutputFormat.pax}) async {
   final proc = await startTar(args);
-  await entries.pipe(tar.tarWritingSink(proc.stdin));
+  await entries.pipe(tar.tarWritingSink(proc.stdin, format: format));
 
   return proc;
 }

--- a/test/windows_integration_test.dart
+++ b/test/windows_integration_test.dart
@@ -1,0 +1,23 @@
+@TestOn('windows')
+import 'dart:io';
+
+import 'package:tar/tar.dart';
+import 'package:test/test.dart';
+
+import 'system_tar.dart';
+
+void main() {
+  test('emits long file names that are understood by 7zip', () async {
+    final name = 'name' * 40;
+    final entry = TarEntry.data(TarHeader(name: name), []);
+    final file = File(Directory.systemTemp.path + '\\tar_test.tar');
+    addTearDown(file.delete);
+
+    await Stream.value(entry)
+        .transform(tarWriterWith(format: OutputFormat.gnuLongName))
+        .pipe(file.openWrite());
+
+    final proc = await Process.start('7za.exe', ['l', file.path]);
+    expect(proc.lines, emitsThrough(contains(name)));
+  });
+}

--- a/test/writer_test.dart
+++ b/test/writer_test.dart
@@ -49,8 +49,9 @@ void main() {
       emits(
         allOf(
           contains('-rwxr--r--'),
-          contains('my_user/long group that exceeds 32 characters'),
-          contains('2020-12-30 12:34'),
+          contains('my_user'),
+          contains('long group that exceeds 32 characters'),
+          contains('12:34'),
         ),
       ),
     );

--- a/test/writer_test.dart
+++ b/test/writer_test.dart
@@ -77,8 +77,7 @@ void main() {
     void shouldThrow(tar.TarEntry entry) {
       final output = tar.tarWritingSink(_NullStreamSink(),
           format: tar.OutputFormat.gnuLongName);
-      expect(
-          Stream.value(entry).pipe(output), throwsA(isA<tar.TarException>()));
+      expect(Stream.value(entry).pipe(output), throwsA(isUnsupportedError));
     }
 
     test('when they are too large', () {

--- a/test/writer_test.dart
+++ b/test/writer_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:test/test.dart';
@@ -76,11 +75,10 @@ void main() {
 
   group('refuses to write files with OutputFormat.gnu', () {
     void shouldThrow(tar.TarEntry entry) {
-      final output = File('/dev/null').openWrite();
+      final output = tar.tarWritingSink(_NullStreamSink(),
+          format: tar.OutputFormat.gnuLongName);
       expect(
-          Stream.value(entry).pipe(
-              tar.tarWritingSink(output, format: tar.OutputFormat.gnuLongName)),
-          throwsA(isA<tar.TarException>()));
+          Stream.value(entry).pipe(output), throwsA(isA<tar.TarException>()));
     }
 
     test('when they are too large', () {
@@ -110,4 +108,26 @@ void main() {
       );
     });
   });
+}
+
+class _NullStreamSink<T> extends StreamSink<T> {
+  @override
+  void add(T event) {}
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    // ignore: only_throw_errors
+    throw error;
+  }
+
+  @override
+  Future<void> addStream(Stream<T> stream) {
+    return stream.forEach(add);
+  }
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => close();
 }

--- a/test/writer_test.dart
+++ b/test/writer_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:tar/tar.dart' as tar;
 import 'package:test/test.dart';
 
-import 'package:tar/tar.dart' as tar;
 import 'system_tar.dart';
 
 const oneMbSize = 1024 * 1024;

--- a/tool/download_7za.dart
+++ b/tool/download_7za.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+
+Future<void> main() async {
+  final client = HttpClient();
+  final request = await client.getUrl(Uri.parse(
+      'https://storage.googleapis.com/simon-public-euw3/assets/7za.exe'));
+  final response = await request.close();
+
+  await response.pipe(File('7za.exe').openWrite());
+  client.close();
+}


### PR DESCRIPTION
- Add a `format` option to choose between gnu-style / pax
- forbid writing files that can't be represented in the selected formatting option
- Start running tests on Windows and macOS as well

Closes #12 