### PR TITLE
TarEntryEncoder: synchronous encoding of tar entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.4.1
+## 0.5.0
 
-- Support sync encoding with `TarEntryEncoder`.
+- Support sync encoding with `tarConverter`.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Support sync encoding with `TarEntryEncoder`.
+
 ## 0.4.0
 
 - Support generating tar files with GNU-style long link names

--- a/README.md
+++ b/README.md
@@ -136,15 +136,15 @@ written synchronously too.
 To synchronously write tar files, use `tarConverter` (or `tarConverterWith` for options):
 
 ```dart
-Uint8List createTarArchive(Iterable<SynchronousTarEntry> entries) {
-  final result = BytesBuilder(copy: false);
-  final sink = ByteConversionSink.withCallback(result.add);
+List<int> createTarArchive(Iterable<SynchronousTarEntry> entries) {
+  late List<int> result;
+  final sink = ByteConversionSink.withCallback((data) => result = data);
 
   final output = tarConverter.startChunkedConversion(sink);
   entries.forEach(output.add);
   output.close();
 
-  return result.takeBytes();
+  return result;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Future<void> write(Stream<TarEntry> entries) {
 
 A more complex example for writing files can be found in [`example/archive_self.dart`](example/archive_self.dart).
 
-Note that, by default, tar files are  written in the pax format defined by the
+### Encoding options
+
+By default, tar files are  written in the pax format defined by the
 POSIX.1-2001 specification (`--format=posix` in GNU tar).
 When all entries have file names shorter than 100 chars and a size smaller 
 than 8 GB, this is equivalent to the `ustar` format. This library won't write
@@ -124,6 +126,27 @@ Future<void> write(Stream<TarEntry> entries) {
 
 To change the output format on the `tarWriter` transformer, use
 `tarWriterWith`.
+
+### Synchronous writing
+
+As the content of tar entries is defined as an asynchronous stream, the tar encoder is asynchronous too.
+The more specific `SynchronousTarEntry` class stores tar content as a list of bytes, meaning that it can be
+written synchronously too.
+
+To synchronously write tar files, use `tarConverter` (or `tarConverterWith` for options):
+
+```dart
+Uint8List createTarArchive(Iterable<SynchronousTarEntry> entries) {
+  final result = BytesBuilder(copy: false);
+  final sink = ByteConversionSink.withCallback(result.add);
+
+  final output = tarConverter.startChunkedConversion(sink);
+  entries.forEach(output.add);
+  output.close();
+
+  return result.takeBytes();
+}
+```
 
 ## Features
 

--- a/lib/src/entry.dart
+++ b/lib/src/entry.dart
@@ -54,13 +54,6 @@ class TarEntry {
   /// Creates an in-memory tar entry from the [header] and the [data] to store.
   factory TarEntry.data(TarHeader header, List<int> data) {
     (header as HeaderImpl).size = data.length;
-    return TarEntry$WithData._(header, Stream.value(data), data);
+    return TarEntry._(header, Stream.value(data));
   }
-}
-
-/// A tar entry that is known to contain the data in memory.
-class TarEntry$WithData extends TarEntry {
-  final List<int> data;
-  TarEntry$WithData._(TarHeader header, Stream<List<int>> contents, this.data)
-      : super._(header, contents);
 }

--- a/lib/src/entry.dart
+++ b/lib/src/entry.dart
@@ -52,8 +52,17 @@ class TarEntry {
   TarEntry._(this.header, this.contents);
 
   /// Creates an in-memory tar entry from the [header] and the [data] to store.
-  factory TarEntry.data(TarHeader header, List<int> data) {
+  static SynchronousTarEntry data(TarHeader header, List<int> data) {
     (header as HeaderImpl).size = data.length;
-    return TarEntry._(header, Stream.value(data));
+    return SynchronousTarEntry._(header, data);
   }
+}
+
+/// A tar entry stored in memory.
+class SynchronousTarEntry extends TarEntry {
+  /// The contents of this tar entry as a byte array.
+  final List<int> data;
+
+  SynchronousTarEntry._(TarHeader header, this.data)
+      : super._(header, Stream.value(data));
 }

--- a/lib/src/entry.dart
+++ b/lib/src/entry.dart
@@ -54,6 +54,13 @@ class TarEntry {
   /// Creates an in-memory tar entry from the [header] and the [data] to store.
   factory TarEntry.data(TarHeader header, List<int> data) {
     (header as HeaderImpl).size = data.length;
-    return TarEntry(header, Stream.value(data));
+    return TarEntry$WithData._(header, Stream.value(data), data);
   }
+}
+
+/// A tar entry that is known to contain the data in memory.
+class TarEntry$WithData extends TarEntry {
+  final List<int> data;
+  TarEntry$WithData._(TarHeader header, Stream<List<int>> contents, this.data)
+      : super._(header, contents);
 }

--- a/lib/tar.dart
+++ b/lib/tar.dart
@@ -9,7 +9,7 @@ import 'src/reader.dart';
 import 'src/writer.dart';
 
 export 'src/constants.dart' show TypeFlag;
-export 'src/entry.dart';
+export 'src/entry.dart' show TarEntry;
 export 'src/exception.dart';
 export 'src/format.dart';
 export 'src/header.dart' show TarHeader;

--- a/lib/tar.dart
+++ b/lib/tar.dart
@@ -9,7 +9,7 @@ import 'src/reader.dart';
 import 'src/writer.dart';
 
 export 'src/constants.dart' show TypeFlag;
-export 'src/entry.dart' show TarEntry;
+export 'src/entry.dart' show TarEntry, SynchronousTarEntry;
 export 'src/exception.dart';
 export 'src/format.dart';
 export 'src/header.dart' show TarHeader;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tar
 description: Memory-efficient, streaming implementation of the tar file format
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/simolus3/tar/
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tar
 description: Memory-efficient, streaming implementation of the tar file format
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/simolus3/tar/
 
 environment:

--- a/test/windows_integration_test.dart
+++ b/test/windows_integration_test.dart
@@ -13,7 +13,7 @@ void main() {
     final file = File(Directory.systemTemp.path + '\\tar_test.tar');
     addTearDown(file.delete);
 
-    await Stream.value(entry)
+    await Stream<TarEntry>.value(entry)
         .transform(tarWriterWith(format: OutputFormat.gnuLongName))
         .pipe(file.openWrite());
 


### PR DESCRIPTION
- This is a required feature for pub.dev's `pub_dartdoc` process, as it is based on sync file IO.
- https://github.com/dart-lang/pub-dev/issues/4807
- I've kept the changes in small-step commits, I think it will allow to track that most changes are refactor only, without any change in the functionality.