### PR TITLE
Decode Tar archives with malformed UTF-8 data in headers

### DIFF
--- a/lib/src/reader.dart
+++ b/lib/src/reader.dart
@@ -754,6 +754,10 @@ class PaxHeaders extends UnmodifiableMapBase<String, String> {
     final map = <String, String>{};
     final sparseMap = <String>[];
 
+    // NB: Some Tar files have malformed UTF-8 data in the headers, we should
+    // decode them anyways even if they're broken
+    final utf8Decoder = Utf8Decoder(allowMalformed: true);
+
     Never error() => throw TarException.header('Invalid PAX record');
 
     while (offset < data.length) {
@@ -795,13 +799,13 @@ class PaxHeaders extends UnmodifiableMapBase<String, String> {
         error();
       }
 
-      final key = utf8.decoder.convert(data, offset, nextEquals);
+      final key = utf8Decoder.convert(data, offset, nextEquals);
       // Skip over the equals sign
       offset = nextEquals + 1;
 
       // Subtract one for trailing newline
       final endOfValue = endOfEntry - 1;
-      final value = utf8.decoder.convert(data, offset, endOfValue);
+      final value = utf8Decoder.convert(data, offset, endOfValue);
 
       if (!_isValidPaxRecord(key, value)) {
         error();


### PR DESCRIPTION
Some Tar archives suck and leave malformed data in their headers, such as the [Arch Linux bootstrap image](http://mirror.rackspace.com/archlinux/iso/2022.02.01/archlinux-bootstrap-2022.02.01-x86_64.tar.gz).

To make these decodable via tar, we need to not throw when handling these entries
