### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,9 @@ name: tar
 description: Memory-efficient, streaming implementation of the tar file format
 version: 1.0.4
 repository: https://github.com/simolus3/tar/
+topics:
+ - tar
+ - archive
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to `pubspec.yaml` as follows:

```yaml
topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics