### PR TITLE
Fix hidden files detection in example

### DIFF
--- a/example/archive_self.dart
+++ b/example/archive_self.dart
@@ -28,7 +28,7 @@ Stream<TarEntry> findEntries() async* {
     final name = p.relative(entry.path, from: root.path);
 
     // Let's also ignore hidden directories and files.
-    if (name.startsWith('.')) continue;
+    if (name.split(p.separator).any((part) => part.startsWith('.'))) continue;
 
     // Finally, we should ignore the output file since weird things may happen
     // otherwise.


### PR DESCRIPTION
Thank you so much for creating another great package!

I was just getting started when I spotted a bug in the hidden files detection in the example. Since `name` is actually a relative path, every path segment should be checked, not just the root entity (to catch cases like `subdir/.hidden`).

This might be useful for other lazy folks like me who use the example as a starting point ;)
